### PR TITLE
Prevent incorrect issue merging

### DIFF
--- a/birch_girder/config.example.yaml
+++ b/birch_girder/config.example.yaml
@@ -22,6 +22,10 @@ provider_name: Example Corporation
 initial_email_reply: Thanks for contacting us. We will get back to you as soon
   as possible. You can reply to this email if you have additional information
   to add to your request.
+# Whether or not to allow issues to be merged which come from an email that is
+# not a reply to the existing issue and doesn't have the existing issue's
+# issue number in the subject, but merely has a matching subject line.
+allow_issue_merging_by_subject: True
 # A list of email addresses of senders that should not be sent the initial email
 # reply because they are other companies ticketing systems, not a person
 known_machine_senders:


### PR DESCRIPTION
This adds a new feature and changes the existing issue merging behavior
1. There's now a new config setting, `allow_issue_merging_by_subject` to either enable or disable issue merging by subject. With this setting set to False, no subject based issue merging will happen.
2. When `allow_issue_merging_by_subject` is enabled, emails which match the subject of an existing issue must now be sent by the same sender as that which created the existing issue.

* Change a few logger.log lines to logger.debug
* Starts recording the `source` email address in issue metadata instead of just the `from` field

Fixes #18