### PR TITLE
Add support for optional config setting historical_github_usernames

### DIFF
--- a/birch_girder/__init__.py
+++ b/birch_girder/__init__.py
@@ -1005,12 +1005,13 @@ to add to your request.''')
                 'GitHub IssueCommentEvent action in SNS message was "%s" so '
                 'it will be ignored' % message['action'])
             return False
-        if message['issue']['user']['login'] != self.config['github_username']:
+        github_usernames = self.config.get('historical_github_usernames', []) + [self.config['github_username']]
+        if message['issue']['user']['login'] not in github_usernames:
             logger.info(
                 'GitHub issue was not created by %s so it will be ignored'
                 % self.config['github_username'])
             return False
-        if message['comment']['user']['login'] == self.config['github_username']:
+        if message['comment']['user']['login'] in github_usernames:
             logger.info(
                 'GitHub issue comment was made by %s so it will be ignored'
                 % self.config['github_username'])

--- a/birch_girder/deploy.py
+++ b/birch_girder/deploy.py
@@ -274,6 +274,9 @@ Girder will use to interact with GitHub''')
         note_url = 'http://github.com/gene1wood/birch-girder'
         scopes = ['repo']
 
+        # Note this method of obtaining a token is now deprecated and stops working later in 2020
+        # https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/
+        # TODO : Replace this with a non deprecated method
         auth = GitHub(config['github_username'], password)
         status, authorization_data = auth.authorizations.post(body={
             'scopes': scopes,


### PR DESCRIPTION
This allows you to set additional names that the github bot user used
in the past. This accommodates cases where you have a repo that was
in the past used by one bot user and is now used by another.