### PR TITLE
Update to Python 3.8 and bugfixes

### DIFF
--- a/birch_girder/__init__.py
+++ b/birch_girder/__init__.py
@@ -11,7 +11,7 @@ import boto3
 from agithub.GitHub import GitHub  # pypi install agithub
 import yaml  # pip install PyYAML
 from dateutil import tz  # sudo pip install python-dateutil
-import email
+import email.utils
 from email_reply_parser import \
     EmailReplyParser  # pip install email_reply_parser
 from email.mime.multipart import MIMEMultipart
@@ -29,9 +29,9 @@ TIME_ZONE = tz.gettz('America/Los_Angeles')
 # Example "Re: [examplecorp/support] Add myself to user list. (#2)"
 # https://stackoverflow.com/questions/9153629/regex-code-for-removing-fwd-re-etc-from-email-subject/11640925#comment81160171_11640925
 EMAIL_SUBJECT_PREFIX = re.compile(
-    '^([[(] *)?(RE?S?|FYI|RIF|I|FS|VB|RV|ENC|ODP|PD|YNT'
-    '|ILT|SV|VS|VL|AW|WG|ΑΠ|ΣΧΕΤ|ΠΡΘ|תגובה|הועבר|主题|转发|FWD?)'
-    ' *([-:;)\]][ :;\])-]*|$)|\]+ *$',
+    r'^([\[(] *)?(RE?S?|FYI|RIF|I|FS|VB|RV|ENC|ODP|PD|YNT'
+    r'|ILT|SV|VS|VL|AW|WG|ΑΠ|ΣΧΕΤ|ΠΡΘ|תגובה|הועבר|主题|转发|FWD?)'
+    r' *([-:;)\]][ :;\])-]*|$)|]+ *$',
     re.IGNORECASE)
 
 # "[examplecorp/support] Add myself to user list. (#2)"
@@ -1121,7 +1121,7 @@ def lambda_handler(event, context):
     """
     # logger.debug('got event {}'.format(event))
     with open('config.yaml') as f:
-        config = yaml.load(f.read())
+        config = yaml.load(f.read(), Loader=yaml.SafeLoader)
     handler = EventHandler(config, event, context)
     handler.process_event()
 

--- a/birch_girder/__init__.py
+++ b/birch_girder/__init__.py
@@ -900,6 +900,15 @@ class EventHandler:
                 else '''Thanks for contacting us. We will get back to you as soon
 as possible. You can reply to this email if you have additional information
 to add to your request.''')
+            status, html_body = self.gh.markdown.post(
+                body={
+                    'text': body,
+                    'mode': 'gfm',
+                    'context': '%s/%s' % (
+                        parsed_email.github_owner,
+                        parsed_email.github_repo)
+                }
+            )
             text_url = 'https://github.com/%s/%s/issues/%s' % (
                 parsed_email.github_owner,
                 parsed_email.github_repo,
@@ -936,7 +945,7 @@ to add to your request.''')
                     in_reply_to=parsed_email.message_id,
                     references=parsed_email.message_id,
                     html=EMAIL_HTML_TEMPLATE.substitute(
-                        html_body=body.format(html_url),
+                        html_body=html_body.decode('utf-8').format(html_url),
                         **template_args),
                     text=EMAIL_TEXT_TEMPLATE.substitute(
                         text_body=body.format(text_url),

--- a/birch_girder/__init__.py
+++ b/birch_girder/__init__.py
@@ -955,7 +955,7 @@ to add to your request.''')
                 # replied to
                 issue = repo.issues[issue_data['number']]
                 status, reaction_data = issue.reactions.post(
-                    body={'content':'heart'},
+                    body={'content': 'rocket'},
                     headers={
                         'Accept': 'application/vnd.github.squirrel-girl-preview+json'})
                 logger.info('Just added a reaction to issue #%s after sending an email' %
@@ -1111,7 +1111,7 @@ to add to your request.''')
             comment = (self.gh.repos[message['repository']['full_name']].
                 issues.comments[message['comment']['id']])
             status, reaction_data = comment.reactions.post(
-                body={'content':'heart'},
+                body={'content': 'rocket'},
                 headers={
                     'Accept': 'application/vnd.github.squirrel-girl-preview+json'})
             logger.info('Just added a reaction to a comment in issue #%s after '

--- a/birch_girder/__init__.py
+++ b/birch_girder/__init__.py
@@ -953,13 +953,23 @@ to add to your request.''')
 
                 # Add a reaction to the issue indicating the sender has been
                 # replied to
+                repo = (
+                    self.gh.repos[parsed_email.github_owner][parsed_email.github_repo])
                 issue = repo.issues[issue_data['number']]
                 status, reaction_data = issue.reactions.post(
                     body={'content': 'rocket'},
                     headers={
                         'Accept': 'application/vnd.github.squirrel-girl-preview+json'})
-                logger.info('Just added a reaction to issue #%s after sending an email' %
-                            issue_data['number'])
+                if int(status / 100) == 2:
+                    logger.info(
+                        'Just added a reaction to issue #%s after sending '
+                        'an email' % issue_data['number'])
+                else:
+                    logger.error(
+                        'Unable to add reaction to issue #%s after %s : %s' % (
+                            issue_data['number'],
+                            status,
+                            reaction_data))
             else:
                 message_id = '1'
             logger.debug(

--- a/birch_girder/deploy.py
+++ b/birch_girder/deploy.py
@@ -15,7 +15,6 @@ import hashlib
 import yaml  # pip install PyYAML
 import boto3
 from agithub.GitHub import GitHub  # pip install agithub
-import agithub.base
 from base64 import b64encode
 from nacl import encoding, public
 
@@ -81,7 +80,7 @@ def get_two_factor_code():
 
 
 def green_print(data):
-    print(GREEN_COLOR + data + END_COLOR)
+    print('%s%s%s' % (GREEN_COLOR, data, END_COLOR))
 
 
 def color_getpass(prompt):
@@ -339,7 +338,7 @@ an SNS topic created that internal Birch Girder errors will be sent to.''')
             'Version': '2008-10-17',
             'Statement': []
         }
-    if (statement_id not in [x['Sid'] for x in policy['Statement']]):
+    if statement_id not in [x['Sid'] for x in policy['Statement']]:
         policy['Statement'].append(
             {
                 'Sid': statement_id,
@@ -662,7 +661,7 @@ they're complete''')
     layers = get_paginated_results('lambda', 'list_layers', 'Layers')
     layer_name = '%s-layer' % args.lambda_function_name
     publish_layer = False
-    with open(zip_file_name) as f:
+    with open(zip_file_name, mode='rb') as f:
         try:
             hash_map_file = open(hash_version_map_filename)
             hash_map = json.load(hash_map_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ agithub
 PyYAML
 python-dateutil
 email_reply_parser
-pyzmail
+pyzmail36
 beautifulsoup4

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='birch_girder',
-    version='1.0.0',
+    version='1.1.0',
     description='An Email Interface for GitHub Issues',
     long_description=long_description,
     url='https://github.com/gene1wood/birch-girder',
@@ -23,8 +23,8 @@ setup(
         'Intended Audience :: System Administrators',
         'Topic :: Software Development :: Bug Tracking',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
     ],
     keywords='aws lambda github issue ses',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
@@ -35,7 +35,7 @@ setup(
         'PyYAML',
         'python-dateutil',
         'email_reply_parser',
-        'pyzmail',
+        'pyzmail36',
         'beautifulsoup4'],
     extras_require={
         "deploy":  ["pynacl", "boto3", "PyYAML", "agithub"]


### PR DESCRIPTION
* Update to use Python 3.8
  * This also produces a new artifact zip with new libraries built for 3.8
* Update build-and-upload-birch-girder doc to include docker method
  * Also remove out of date deployment methods from before we switched
to using Lambda Layers
* Fix setting reaction on initial email
  * This was caused by an oddity of agithub
  * Fixes #32
* Switch reaction to sending an email from heart to rocket
  * Seems like a rocket is a better indication of sending something
    whereas a heart is more of an endorsement of something
* Render initial email reply into HTML from Markdown for HTML email
* Various small fixes and tweaks
