### PR TITLE
Change reply parsing to use text version of email if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ for free (as in beer).
 
 * A free GitHub user account
 * A free Amazon Web Services (AWS) account. This requires giving AWS a credit
-  card but as long as you send and receive 1000 emails or less per month it's
+  card but as long as you receive 1000 emails or less per month it's
   free ([$0.10 for every additional 1000 emails](https://aws.amazon.com/ses/pricing/))
 * A domain name for which you can have all email destined to addresses in that
   domain, sent to AWS. This can be a subdomain of an existing domain. If you have

--- a/birch_girder/__init__.py
+++ b/birch_girder/__init__.py
@@ -454,7 +454,7 @@ class Email:
         if not self.raw_body:
             self.get_email_payload()
             self.parse_email_payload()
-        self.stripped_reply = EmailReplyParser.parse_reply(self.email_body)
+        self.stripped_reply = EmailReplyParser.parse_reply(self.email_body_text if self.email_body_text != '' else self.email_body)
 
     def parse_subject(self):
         """Parse the raw email subject, stripping off the leading Re: and

--- a/birch_girder/deploy.py
+++ b/birch_girder/deploy.py
@@ -27,17 +27,22 @@ BLUE_COLOR = '\033[94m'
 class Config(collections.abc.MutableMapping):
     def __init__(self, filename, *args, **kwargs):
         self.filename = filename
+        self.save_on_set = False
         self.store = dict()
         self.load()
         self.update(dict(*args, **kwargs))
+        self.save_on_set = True
 
     def __setitem__(self, key, value):
-        self.store[key] = value
-        self.save()
+        if (key not in self.store) or (yaml.dump(value) != yaml.dump(self.store[key])):
+            self.store[key] = value
+            if self.save_on_set:
+                self.save()
 
     def __delitem__(self, key):
-        del self.store[key]
-        self.save()
+        if key in self.store:
+            del self.store[key]
+            self.save()
 
     def __getitem__(self, key):
         return self.store[key]
@@ -299,14 +304,16 @@ Girder will use to interact with GitHub''')
     response = client.create_topic(  # This action is idempotent
         Name=config['sns_topic']
     )
-    config['sns_topic_arn'] = response['TopicArn']
+    if config.get('sns_topic_arn') != response['TopicArn']:
+        config['sns_topic_arn'] = response['TopicArn']
 
     # Alert SNS Topic
     if 'alert_sns_topic' in config:
         response = client.create_topic(  # This action is idempotent
             Name=config['alert_sns_topic']
         )
-        config['alert_sns_topic_arn'] = response['TopicArn']
+        if config['alert_sns_topic'] != response['TopicArn']:
+            config['alert_sns_topic_arn'] = response['TopicArn']
     elif early_run:
         print('''No alert_sns_topic in config so no alert topic will be setup.
 You can add an alert topic to config later and re-run deploy if you would like

--- a/birch_girder/deploy.py
+++ b/birch_girder/deploy.py
@@ -702,7 +702,7 @@ they're complete''')
                         % layer_version_arn)
             hash_map[digest] = layer_version_arn
             with open(hash_version_map_filename, 'w') as hash_map_file:
-                json.dump(hash_map, hash_map_file)
+                json.dump(hash_map, hash_map_file, indent=4)
             function_needs_update = True
 
 

--- a/birch_girder/deploy.py
+++ b/birch_girder/deploy.py
@@ -4,7 +4,7 @@
 import os.path
 import time
 import json
-import collections
+import collections.abc
 from getpass import getpass
 import argparse
 import zipfile
@@ -24,7 +24,7 @@ GREEN_COLOR = '\033[92m'
 BLUE_COLOR = '\033[94m'
 
 
-class Config(collections.MutableMapping):
+class Config(collections.abc.MutableMapping):
     def __init__(self, filename, *args, **kwargs):
         self.filename = filename
         self.store = dict()

--- a/birch_girder/deploy.py
+++ b/birch_girder/deploy.py
@@ -657,7 +657,7 @@ they're complete''')
     zip_file_name = 'artifacts/birch-girder.zip'
     hash_version_map_filename = 'artifacts/.hash_version_map.json'
     layers = get_paginated_results('lambda', 'list_layers', 'Layers')
-    layer_name = '%s-layer' % args.lambda_function_name
+    layer_name = 'birch-girder-layer'
     publish_layer = False
     with open(zip_file_name, mode='rb') as f:
         try:

--- a/tests/test_birch-girder.py
+++ b/tests/test_birch-girder.py
@@ -5,7 +5,6 @@ import re
 import cgi
 import logging
 import dateutil.parser
-import uuid
 import boto3
 import requests
 from agithub.GitHub import GitHub
@@ -28,7 +27,7 @@ GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN', 'your-github-token-goes-here')
 WORD_LIST = [line.strip() for line in open('/usr/share/dict/words')]
 SUBJECT_PATTERN = re.compile(r'.*\(#([0-9]+)\)$')
 EMAIL_VERIFICATION_PATTERN = re.compile(
-    r'^https://email-verification\.[^.]+.amazonaws.com/.*$')
+    r'^https://email-verification\.[^.]+\.amazonaws\.com/.*$')
 
 """
 Tests to create


### PR DESCRIPTION
* Change reply parsing to use text version of email if available
  * Fixes #9
* Only write to the config file if a value has changed
* Change the layer name to be fixed as each layer is mapped to a hash
* Make the artifact hash json more readable
* Clarify in the README that the 1000 email free tier is for recieved emails
* Fix unescaped periods in test regex
* Use collections.abc in advance of a change coming in Python 3.9
