### PR TITLE
Support Reply-To and add reactions when email is sent

### DIFF
--- a/docs/build-and-upload-birch-girder.md
+++ b/docs/build-and-upload-birch-girder.md
@@ -2,18 +2,23 @@
 
 ## Create the Lambda Layer
 
-### Method 1 : Use docker
+### Method 1 : Use pip and manylinux2014_x86_64
 
-1. Run this command to fetch a docker image of the lambda environment and build
-   the required packages
+1. Run this command to fetch wheels of the dependencies using the 
+   [`manylinux` project](https://github.com/pypa/manylinux)
    ```
-   docker run -v "$PWD":/var/task \
-     "lambci/lambda:build-python3.8" \
-     /bin/sh -c "python -m pip install -r requirements.txt -t python/lib/python3.8/site-packages/; exit"
+   pip install \
+     --platform manylinux2014_x86_64 \
+     --target=package \
+     --implementation cp \
+     --python-version 3.10 \
+     --only-binary=:all: --upgrade \
+     botocore boto3 agithub PyYAML python-dateutil email_reply_parser pyzmail36 beautifulsoup4
    ```
 2. Zip up the results
    ```
-   zip -r ../birch-girder.zip python
+   cd package
+   zip -r ../artifacts/birch-girder.zip .
    ```
 
 This process is outlined in [this AWS documentation page](https://aws.amazon.com/premiumsupport/knowledge-center/lambda-layer-simulated-docker/).

--- a/docs/build-and-upload-birch-girder.md
+++ b/docs/build-and-upload-birch-girder.md
@@ -7,13 +7,14 @@
 1. Run this command to fetch wheels of the dependencies using the 
    [`manylinux` project](https://github.com/pypa/manylinux)
    ```
+   mkdir -p package/python
    pip install \
      --platform manylinux2014_x86_64 \
-     --target=package \
+     --target=package/python \
      --implementation cp \
-     --python-version 3.10 \
+     --python-version 3.14 \
      --only-binary=:all: --upgrade \
-     botocore boto3 agithub PyYAML python-dateutil email_reply_parser pyzmail36 beautifulsoup4
+     botocore boto3 agithub PyYAML python-dateutil email_reply_parser beautifulsoup4
    ```
 2. Zip up the results
    ```

--- a/emit-comment-to-sns-github-action.yml
+++ b/emit-comment-to-sns-github-action.yml
@@ -32,11 +32,11 @@ jobs:
 
       - name: Configure AWS Credentials
         id: configure-aws
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.BIRCH_GIRDER_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.BIRCH_GIRDER_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.BIRCH_GIRDER_SNS_TOPIC_REGION }}
       - name: Emit issue comment to AWS SNS
         id: emit-comment
-        run: echo "::set-output name=message_id::$(aws sns publish --topic-arn $BIRCH_GIRDER_SNS_TOPIC_ARN --message file://$GITHUB_EVENT_PATH --output text --query MessageId)"
+        run: echo "name=message_id::$(aws sns publish --topic-arn $BIRCH_GIRDER_SNS_TOPIC_ARN --message file://$GITHUB_EVENT_PATH --output text --query MessageId)" >> $GITHUB_OUTPUT

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ agithub
 PyYAML
 python-dateutil
 email_reply_parser
-pyzmail36
 beautifulsoup4

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='birch_girder',
-    version='1.2.0',
+    version='1.3.0',
     description='An Email Interface for GitHub Issues',
     long_description=long_description,
     url='https://github.com/gene1wood/birch-girder',
@@ -35,10 +35,10 @@ setup(
         'PyYAML',
         'python-dateutil',
         'email_reply_parser',
-        'pyzmail36',
-        'beautifulsoup4'],
+        'beautifulsoup4',
+        'aws-lambda-persistence'],
     extras_require={
-        "deploy":  ["pynacl", "boto3", "PyYAML", "agithub"]
+        "deploy":  ["pynacl", "boto3", "PyYAML", "agithub", "aws-lambda-persistence"]
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Consume SES events (Bounce Complaint Delivery) and add reaction emojis to
the associated comment in the GitHub issue to indicate if the email sent to
the reporter was successful. This new functionality is found in the 
`process_ses_notification` method.

Begin including the aws-lambda-persistence layer in the AWS Lambda function.

Use AWS Lambda Persistence to store information about emails sent to the
reporter for later use when the SES notification event comes in.

Begin using the Reply-To email header instead of From when it's present

Added new SEND_REPLAY_EMAIL environment variable. This affects whether an
email is sent to a reporter when a "replay-email" event is triggered. If
SEND_REPLAY_EMAIL is set to "False", then an email won't be sent. This is
useful if there was a problem and you need to trigger a "replay-email" event
but don't want to generate and send a new email.

Update the Python runtime version to 3.14 and Python dependencies to newest
versions

Fix problem with JSON serializing base64 bytes in deploy.py

Improve AWS Lambda event type detection to make it more durable

Replaced pyzmail with the Python email module

Update build instructions from using docker to manylinux 

Update GitHub actions template

This upgrades to a newer configure-aws-credentials action
and uses the newer preferred output method.
This will stop the warning messages in GitHub actions.

Fixes #15